### PR TITLE
Implement delete api and couple of fixes

### DIFF
--- a/flight_declaration_operations/urls.py
+++ b/flight_declaration_operations/urls.py
@@ -38,4 +38,9 @@ urlpatterns = [
         "flight_declaration_state/<uuid:pk>",
         flight_declaration_views.FlightDeclarationStateUpdate.as_view(),
     ),
+    path(
+        "flight_declaration/<uuid:declaration_id>/delete",
+        flight_declaration_views.FlightDeclarationDelete.as_view(),
+        name="flight-declaration-delete",
+    ),
 ]

--- a/flight_feed_operations/views.py
+++ b/flight_feed_operations/views.py
@@ -454,7 +454,7 @@ def set_telemetry(request):
         unsigned_telemetry_observations.append(asdict(single_observation_set, dict_factory=NestedDict))
         operation_id = f_details.id
         now = arrow.now().isoformat()
-        relevant_operation_ids_qs = my_argon_server_database_reader.get_current_flight_declaration_ids(now=now)
+        relevant_operation_ids_qs = my_argon_server_database_reader.get_current_flight_declaration_ids(timestamp=now)
         relevant_operation_ids = [str(o) for o in relevant_operation_ids_qs.all()]
         if operation_id in list(relevant_operation_ids):
             # Get flight state:


### PR DESCRIPTION
This PR contains following changes:
1. Implement delete endpoint for the flight declaration, to avoid the flight state going into "rejected" on successive declarations
2. Fix the database retrieval so that we return the updated value to the caller and the verification check doesn't fail
3. Pass the correct arg to get_current_flight_declaration_ids()